### PR TITLE
fix(parseWei): rounds to decimal places using toFixed

### DIFF
--- a/src/FixedPointX64.ts
+++ b/src/FixedPointX64.ts
@@ -45,14 +45,14 @@ export class FixedPointX64 {
    * @return Parsed value floored and scaled down by 10**decimals
    */
   get float(): number {
-    return this.parsed / 10 ** this.decimals
+    return this.parsed / Math.pow(10, this.decimals)
   }
 
   /**
    * @return Float value divided by 1e4, the precision of Percentage values
    */
   get percentage(): number {
-    return this.parsed / 10 ** Percentage.Mantissa
+    return this.parsed / Math.pow(10, Percentage.Mantissa)
   }
 
   toString(): string {

--- a/src/Percentage.ts
+++ b/src/Percentage.ts
@@ -7,7 +7,9 @@ import { toBN } from './utils'
  * @returns Percentage class with a raw percentage value scaled by 1e4
  */
 export const parsePercentage = (percent: number): Percentage => {
-  return new Percentage(toBN(percent * Math.pow(10, Percentage.Mantissa)))
+  const scalar = Math.pow(10, Percentage.Mantissa)
+  const floored = Math.floor(percent * scalar)
+  return new Percentage(toBN(floored))
 }
 
 /**

--- a/src/Time.ts
+++ b/src/Time.ts
@@ -42,6 +42,11 @@ export class Time {
     return +Date.now() / 1000
   }
 
+  add(x: BigNumberish | Time): Time {
+    x = x.toString()
+    return new Time(this.raw + +x.toString())
+  }
+
   sub(x: BigNumberish | Time): Time {
     x = x.toString()
     return new Time(this.raw - +x.toString())

--- a/src/Wei.ts
+++ b/src/Wei.ts
@@ -6,8 +6,8 @@ import { formatUnits, parseUnits } from '@ethersproject/units'
  * @param  x Amount to parse to raw wei value
  * @param  decimals Amount of precision that the raw wei value would have
  */
-export const parseWei = (x: BigNumberish, decimals: number = 18): Wei => {
-  return new Wei(parseUnits(x.toString(), decimals), decimals)
+export function parseWei(x: BigNumberish, decimals: number = 18): Wei {
+  return new Wei(parseUnits((+x.toString()).toFixed(decimals), decimals), decimals)
 }
 
 /**
@@ -70,6 +70,10 @@ export class Wei {
     return this.raw.lte(x.toString())
   }
 
+  eq(x: BigNumberish | Wei): boolean {
+    return this.raw.eq(x.toString())
+  }
+
   log() {
     console.log(this.parsed)
   }
@@ -79,7 +83,7 @@ export class Wei {
   }
 
   /**
-   * @return Mantissa used to scale uint values in the smart contracts
+   * @return Default decimals
    */
   static get Mantissa(): number {
     return 18

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,5 +4,15 @@ import { BigNumber, BigNumberish } from '@ethersproject/bignumber'
  * @notice Converts to a BigNumber
  */
 export const toBN = (val: BigNumberish): BigNumber => {
-  return BigNumber.from(val.toString())
+  const floored = Math.floor(+val.toString())
+  return BigNumber.from(floored.toString())
+}
+
+/**
+ * Converts a Big Number to a hex string
+ * @param BigNumber
+ * @returns bn as a hex string
+ */
+export function toHex(bn: BigNumber) {
+  return bn.toHexString()
 }

--- a/test/Percentage.test.ts
+++ b/test/Percentage.test.ts
@@ -3,7 +3,7 @@ import { parsePercentage, Percentage, toBN } from '../src'
 describe('Percentage', function() {
   it('parsePercentage', async function() {
     const value = 1.25
-    expect(parsePercentage(value).raw).toStrictEqual(toBN(value * Math.pow(10, Percentage.Mantissa)))
+    expect(parsePercentage(value).raw).toStrictEqual(toBN(Math.floor(value * Math.pow(10, Percentage.Mantissa))))
   })
 
   it('float', async function() {

--- a/test/Wei.test.ts
+++ b/test/Wei.test.ts
@@ -22,6 +22,24 @@ describe('Wei', function() {
     expect(value.gt(parseEther('0.5'))).toBe(true)
   })
 
+  it('parseWei#decimal value', async function() {
+    const amount = 1.043534563463461132123123121231
+    const value = parseWei(amount)
+    expect(value.raw).toStrictEqual(parseEther(amount.toFixed(18)))
+  })
+
+  it('parseWei#scientific notation', async function() {
+    const amount = 1.04353e-7
+    const value = parseWei(amount)
+    expect(value.raw).toStrictEqual(parseEther(amount.toFixed(18)))
+  })
+
+  it('parseWei#string', async function() {
+    const amount = '120120556345.312315'
+    const value = parseWei(amount)
+    expect(value.raw).toStrictEqual(parseEther((+amount).toFixed(18)))
+  })
+
   it('parseWei#0 decimals', async function() {
     const decimals = 0
     const amount = 2


### PR DESCRIPTION
# Changelog
- Floors value in parsePercentage
- Uses toFixed(decimals) before scaling up in `parseWei`
- Adds an `add` function to `Time`
- Updates FixedPointX64 with appropriate ways to multiply by mantissas
- Adds `toHex` function in `utils`
- Adds additional tests to `wei` and `percentage` to handle different value types, like scientific notation