### PR TITLE
fix(wei-div): updates dividing by 0 condition to throw

### DIFF
--- a/src/Wei.ts
+++ b/src/Wei.ts
@@ -84,7 +84,7 @@ export class Wei {
   }
 
   div(x: BigNumberish | Wei): Wei {
-    if (+x.toString() <= 0) return parseWei('0')
+    if (+x.toString() <= 0) throw Error('Attempting to divide by 0 or negative')
     return new Wei(this.raw.div(x.toString()), this.decimals)
   }
 

--- a/test/Wei.test.ts
+++ b/test/Wei.test.ts
@@ -83,6 +83,11 @@ describe('Wei', function() {
     expect(+value.div(2).toString()).toBe(1)
   })
 
+  it('Wei#div by 0', async function() {
+    const value = new Wei(toBN(2))
+    expect(() => value.div(0)).toThrow()
+  })
+
   it('Wei#gt', async function() {
     const value = new Wei(toBN(2))
     expect(value.gt(1)).toBe(true)


### PR DESCRIPTION
# Changelog
- Updates Wei `div` function to throw when dividing by 0 or a negative value